### PR TITLE
communicating tests for pythonshare

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,15 @@ stages:
   - build
   - test
 
+variables:
+  HUB_CONNSPEC: xyz@pythonshare-server
+  HUB_NS: logger
+
+services:
+- name: askervin/pythonshare-server
+  alias: pythonshare-server
+  entrypoint: ["pythonshare-server", "-d", "--interface=all", "--password=xyz", "-n", $HUB_NS]
+
 build_ubuntu_bionic:
   image: ubuntu:bionic
   stage: build
@@ -84,64 +93,69 @@ build_windows_32:
 test_ubuntu_bionic:
   image: ubuntu:bionic
   stage: test
+  variables:
+    TEST_ENV: ubuntu_bionic
   dependencies:
     - build_ubuntu_bionic
-  services:
-    - askervin/pythonshare-server
   script:
     - cd debs
     - apt-get update
     - DEBIAN_FRONTEND=noninteractive apt install -f -y ./fmbt-pythonshare*.deb
-    - pythonshare-client -C xyz@askervin-pythonshare-server --ls-remote
+    - pythonshare-client -C $HUB_CONNSPEC --ls-remote
+    - python ../pythonshare/tests/onlinetests.py
 
 test_ubuntu_xenial:
   image: ubuntu:xenial
   stage: test
+  variables:
+    TEST_ENV: ubuntu_xenial
   dependencies:
     - build_ubuntu_xenial
-  services:
-    - askervin/pythonshare-server
   script:
     - cd debs
     - apt-get update
     - DEBIAN_FRONTEND=noninteractive apt install -f -y ./fmbt-pythonshare*.deb
-    - pythonshare-client -C xyz@askervin-pythonshare-server --ls-remote
+    - pythonshare-client -C $HUB_CONNSPEC --ls-remote
+    - python ../pythonshare/tests/onlinetests.py
 
 test_debian_stable:
   image: debian:stable
   stage: test
+  variables:
+    TEST_ENV: debian_stable
   dependencies:
     - build_debian_stable
-  services:
-    - askervin/pythonshare-server
   script:
     - cd debs
     - apt-get update
     - DEBIAN_FRONTEND=noninteractive apt install -f -y ./fmbt-pythonshare*.deb
-    - pythonshare-client -C xyz@askervin-pythonshare-server --ls-remote
+    - pythonshare-client -C $HUB_CONNSPEC --ls-remote
+    - python ../pythonshare/tests/onlinetests.py
 
 test_debian_unstable:
   image: debian:unstable
   stage: test
+  variables:
+    TEST_ENV: debian_unstable
   dependencies:
     - build_debian_unstable
-  services:
-    - askervin/pythonshare-server
   script:
     - cd debs
     - apt-get update
     - DEBIAN_FRONTEND=noninteractive apt install -f -y ./fmbt-pythonshare*.deb
-    - pythonshare-client -C xyz@askervin-pythonshare-server --ls-remote
+    - pythonshare-client -C $HUB_CONNSPEC --ls-remote
+    - python ../pythonshare/tests/onlinetests.py
 
 test_debian_testing:
   image: debian:testing
   stage: test
+  variables:
+    TEST_ENV: debian_testing
   dependencies:
     - build_debian_testing
-  services:
-    - askervin/pythonshare-server
   script:
     - cd debs
     - apt-get update
     - DEBIAN_FRONTEND=noninteractive apt install -f -y ./fmbt-pythonshare*.deb
-    - pythonshare-client -C xyz@askervin-pythonshare-server --ls-remote
+    - pythonshare-client -C $HUB_CONNSPEC --ls-remote
+    - python ../pythonshare/tests/onlinetests.py

--- a/pythonshare/tests/onlinetests.py
+++ b/pythonshare/tests/onlinetests.py
@@ -1,0 +1,27 @@
+### Online tests for pythonshare
+###
+### Copyright Jukka Laukkanen / Dashing Test Automation
+### jukka@dashing.fi
+###
+
+import os
+import sys
+import pythonshare
+
+HUB_CONNSPEC = os.getenv("HUB_CONNSPEC", "xyz@localhost")
+HUB_NS = os.getenv("HUB_NS", "logger")
+TEST_ENV = os.getenv("TEST_ENV", "na")
+
+password = HUB_CONNSPEC.split("@")[0]
+
+# don't catch the exception, all failures needs to fail the test
+print "Trying to connect to %s/%s" % (HUB_CONNSPEC, HUB_NS)
+hub = pythonshare.connect(HUB_CONNSPEC, password, HUB_NS)
+data_in = "data = '%s'" % (TEST_ENV,)
+print "writing to hub: %s" % (data_in,)
+hub.exec_in(HUB_NS, data_in)
+print "reading value of 'data' from hub"
+ret = hub.eval_in(HUB_NS, "data")
+print "value read from hub: %s" % (ret,)
+assert ret == TEST_ENV
+print "Great success"


### PR DESCRIPTION
Add communicating tests for pythonshare

Uses pythonshare-server docker image as a service to
- test pythonshare-client --ls-remote
- test writing to variable in pythonshare namespace
- test reading from variable in pythonshare namespace