### PR TITLE
build python3share debs in ci

### DIFF
--- a/build-fMBT-packages-linux.sh
+++ b/build-fMBT-packages-linux.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-apt-get update; apt-get -y install git dpkg-dev devscripts python debhelper gcc libglib2.0-dev libboost-dev libedit-dev automake libtool libxml2-dev libmagickcore-dev libboost-regex-dev libc6-dev python-dev flex dbus python-pexpect python-dbus python-gobject graphviz imagemagick
+apt-get update; apt-get -y install git dpkg-dev devscripts python debhelper gcc libglib2.0-dev libboost-dev libedit-dev automake libtool libxml2-dev libmagickcore-dev libboost-regex-dev libc6-dev python-dev flex dbus python-pexpect python-dbus python-gobject graphviz imagemagick python3 dh-python
 echo "detected fMBT version $(git describe --tags | sed 's/v//1')"
 dch --empty -b -v $(git describe --tags | sed 's/v//1') --distribution bionic --force-distribution Build by https://gitlab.com/fmbt/fmbt_ci/
 
@@ -16,3 +16,18 @@ mkdir debs
 mv ../*.deb debs
 mv ../*.changes debs
 mv ../*.dsc debs
+
+cd python3share
+dch --empty -b -v $(git describe --tags | sed 's/v//1') --distribution bionic --force-distribution Build by https://gitlab.com/fmbt/fmbt_ci/
+dpkg-buildpackage -us -uc
+EXIT_CODE=$?
+ls -la
+if [ $EXIT_CODE != 0 ]; then
+    mv /tmp/fmbt*.log logs
+    exit ${EXIT_CODE}
+fi
+
+mv ../*.deb ../debs
+mv ../*.changes ../debs
+mv ../*.dsc ../debs
+

--- a/python3share/debian/control
+++ b/python3share/debian/control
@@ -3,8 +3,8 @@ Maintainer: Antti Kervinen <antti.kervinen@intel.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.3
-Build-Depends: dh-python (>= 3.2), python3 (>= 3.6)
-X-Python3-Version: >= 3.6
+Build-Depends: dh-python (>= 2.2), python3 (>= 3.5)
+X-Python3-Version: >= 3.5
 
 Package: python3share
 Architecture: any


### PR DESCRIPTION
modify python3 and python-dh version requirement
to be able to build in debian stretch