### PR TITLE
disable debian unstable and testing pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,29 +47,32 @@ build_debian_stable:
       - logs/*
       - test/*/*.txt
 
-build_debian_unstable:
-  image: debian:unstable
-  stage: build
-  script:
-    - ./build-fMBT-packages-linux.sh
-  artifacts:
-    when: always
-    paths:
-      - debs/*
-      - logs/*
-      - test/*/*.txt
+# debian unstable and testing disabled
+# python2 is not available anymore in those repositories
 
-build_debian_testing:
-  image: debian:testing
-  stage: build
-  script:
-    - ./build-fMBT-packages-linux.sh
-  artifacts:
-    when: always
-    paths:
-      - debs/*
-      - logs/*
-      - test/*/*.txt
+#build_debian_unstable:
+#  image: debian:unstable
+#  stage: build
+#  script:
+#    - ./build-fMBT-packages-linux.sh
+#  artifacts:
+#    when: always
+#    paths:
+#      - debs/*
+#      - logs/*
+#      - test/*/*.txt
+
+#build_debian_testing:
+#  image: debian:testing
+#  stage: build
+#  script:
+#    - ./build-fMBT-packages-linux.sh
+#  artifacts:
+#    when: always
+#    paths:
+#      - debs/*
+#      - logs/*
+#      - test/*/*.txt
 
 build_windows_64:
   image: fedora:23


### PR DESCRIPTION
Disable debian unstable and testing builds as they don't have
python2 anymore.