### PR TITLE
fmbt: account for aal-provided tag numbers starting at 0

### DIFF
--- a/src/awrapper.cc
+++ b/src/awrapper.cc
@@ -72,8 +72,8 @@ void Awrapper::set_tags(std::vector<std::string>* _tags)
       continue;
     }
     
-    tagaal2ada[i]=result;
-    tagada2aal[result]=i;
+    tagaal2ada[i - 1] = result;
+    tagada2aal[result] = i - 1;
 
   }
 }

--- a/src/test_engine.cc
+++ b/src/test_engine.cc
@@ -173,7 +173,7 @@ void Test_engine::verify_tags(const std::vector<std::string>& tnames)
     return;
   }
 
-  std::string s=to_string(cnt,tags,tnames);
+  std::string s = to_string(cnt, tags, std::vector<std::string>(++ tnames.begin(), tnames.end()));
   log.print("<tags enabled=\"%s\"/>\n",s.c_str());
 
   std::vector<int> t;


### PR DESCRIPTION
@askervin 
### Original Issue
- The compiled code from `fmbt-aalc`, which extends `aal` class, returns tag indices starting at 0.
- The `Awrapper::check_tags` method assumes the said indices start at 1.

**Fix**: create an offset of 1 in `Awrapper::tagaal2ada` and `Awrapper::tagada2aal` variables.
*Code has only been tested on the command line interface with a c++ program under test*